### PR TITLE
Added Amazon Linux specific Hashicorp repo

### DIFF
--- a/tasks/repository_install.yml
+++ b/tasks/repository_install.yml
@@ -20,8 +20,18 @@
   get_url:
     url: https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
     dest: /etc/yum.repos.d/hashicorp.repo
-  when: ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+  when: 
+   - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+   - ansible_distribution != 'Amazon'
 
+- name: Installing HashiCorp repository for Amazon Linux
+  get_url:
+    url: https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
+    dest: /etc/yum.repos.d/hashicorp.repo
+  when: 
+   - ansible_pkg_mgr == 'yum' or ansible_pkg_mgr == 'dnf'
+   - ansible_distribution == 'Amazon'
+   
 - name: Add key for apt
   ansible.builtin.apt_key:
     url: https://apt.releases.hashicorp.com/gpg


### PR DESCRIPTION
# Pull request


## Related Issue

NA

## Description

Was Testing role with Amazon Linux.  It's a documented OS in https://learn.hashicorp.com/tutorials/vault/getting-started-install so we should support it in this demo role.

FYI @jacobmammoliti 


## Expectation

please check all the relevant components;

- [ ] Syntax review
- [ ] Code review && test

## How to'

- Spin up EC2 instances with Amazon Linux 2 (eg 3 servers)
- Create and fill out inventory, site.yml and group_vars/vault_primary.yml
- Run ansible-playbook
